### PR TITLE
edit web.config perms to accommodate recent change to supervisor permission behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This will take several minutes to load since it is downloading and installing th
 
 ```
 cd C:\movie-database
-hab studio enter -w
+hab studio enter
 build
 ```
 

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -11,6 +11,12 @@ Invoke-Command -ComputerName localhost -EnableNetworkAccess {
 Import-Module "{{pkgPathFor "core/dsc-core"}}/Modules/DscCore"
 Start-DscCore (Join-Path {{pkg.svc_config_path}} website.ps1) NewWebsite
 
+$pool = "{{cfg.app_pool}}"
+$access = New-Object System.Security.AccessControl.FileSystemAccessRule "IIS APPPOOL\$pool", "ReadAndExecute", "Allow"
+$acl = Get-Acl "{{pkg.svc_config_path}}/Web.config"
+$acl.SetAccessRule($access)
+$acl | Set-Acl "{{pkg.svc_config_path}}/Web.config"
+
 # For some reason the first call always fails, so lets get that over with
 try { Invoke-WebRequest "http://localhost:{{cfg.port}}/default.aspx" -Method Head } catch {}
 

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -55,7 +55,10 @@ function Invoke-Build{
     $proj.Save($csprojPath)
     
     MSBuild.exe $csprojPath /property:Configuration=Release 
-}
+    if($LASTEXITCODE -ne 0) {
+        Write-Error "dotnet build failed!"
+    }
+  }
 
 function Invoke-Install{
     New-Item -ItemType Directory -Path $pkg_prefix/MovieApp


### PR DESCRIPTION
As of v0.66.0, the Supervisor does not include `Users` or `Authenticated Users` in the ACL of the rendered `hooks` and `config` dirs since there could possibly be sensitive data. So only `Administrators`, `SYSTEM` and the user running the Supervisor are given `FullControl` access. This means the IIS app pool user must be given read/execute perms of the rendered web.config.

I made a couple other very small changes here as well.

Also see: https://github.com/habitat-sh/habitat/pull/5788 for more context.